### PR TITLE
Fixing installation on Windows with latest CMake ...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,4 +35,5 @@ install(FILES ${hdrs} "${CMAKE_BINARY_DIR}/greentea_libdnn_config.h"
 
 install(TARGETS ${PROJECT_LIBRARY_TARGET_NAME}
         EXPORT  ${CMAKE_TARGETS_NAME}
+        RUNTIME DESTINATION lib
         LIBRARY DESTINATION lib)


### PR DESCRIPTION
Hi Fabian,

When installing this lib on Windows with cmake 3.5.2 and -DBUILD_SHARED_LIBS=ON, I encountered the following error:

 CMake Error at src/CMakeLists.txt:36 (install):
   install Library TARGETS given no DESTINATION! 

After Googling the problem, the solution was to add the following line to cMakeLists.txt:

 install(TARGETS ${PROJECT_LIBRARY_TARGET_NAME}
         EXPORT  ${CMAKE_TARGETS_NAME}
+        RUNTIME DESTINATION lib
         LIBRARY DESTINATION lib)

Is this the correct solution? If yes, maybe it's better to merge it to the master?
Thanks a lot!
