### PR TITLE
adding ARCHIVE destination for static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,4 +36,5 @@ install(FILES ${hdrs} "${CMAKE_BINARY_DIR}/greentea_libdnn_config.h"
 install(TARGETS ${PROJECT_LIBRARY_TARGET_NAME}
         EXPORT  ${CMAKE_TARGETS_NAME}
         RUNTIME DESTINATION lib
+        ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib)


### PR DESCRIPTION
Sorry for bothering you again, Fabian, but I just had one more addition. Seems that if you want to compile static libraries (i.e. -DBUILD_SHARED_LIBS=OFF) using latest cmake (on both Linux and Windows), you need yet another extra line:

 install(TARGETS ${PROJECT_LIBRARY_TARGET_NAME}
         EXPORT  ${CMAKE_TARGETS_NAME}
         RUNTIME DESTINATION lib
+        ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib)

Thanks!

The rest seems to be working fine ...
