### PR TITLE
Fix Timer can't work for OpenCL implementation.

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -12,6 +12,7 @@
 // #define VIENNACL_DEBUG_ALL 1
 
 #ifdef USE_OPENCL
+#define VIENNACL_PROFILING_ENABLED
 #include "viennacl/backend/opencl.hpp"
 #include "viennacl/ocl/backend.hpp"
 #include "viennacl/ocl/context.hpp"


### PR DESCRIPTION
Timer for OpenCL implementation didn't enable profiling. Fixed it.